### PR TITLE
replace netcat with socat for liveness probe/metrics

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN set -x \
     && apt-get -qq -y --no-install-recommends install \
       gnupg \
       wget \
-      netcat-openbsd \
+      socat \
     && rm -rf /var/lib/apt/lists/*
 
 RUN for key in $APACHE_KEYS; do \

--- a/docker/scripts/zookeeper-metrics
+++ b/docker/scripts/zookeeper-metrics
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo mntr | nc localhost $1 >& 1
+echo mntr | socat STDIO TCP:localhost:$1 >& 1

--- a/docker/scripts/zookeeper-ready
+++ b/docker/scripts/zookeeper-ready
@@ -17,7 +17,7 @@
 # is healthy. The $? variable will be set to 0 if server responds that it is
 # healthy, or 1 if the server fails to respond.
 
-OK=$(echo ruok | nc -q 1 127.0.0.1 $1)
+OK=$(echo ruok | socat STDIO TCP:127.0.0.1:$1)
 if [ "$OK" == "imok" ]; then
 	exit 0
 else


### PR DESCRIPTION
We've had an issue on Google Kubernetes Engine, on a node with
kernel version 4.14.138+, where liveness probes would regularly fail
some percentage of the time.

We've traced the problem down to the `poll()` system call sometimes
failing in the `nc` command used in the liveness probe, whereupon
`nc` returns an empty response, despite the TCP connection from
Zookeeper clearly sending back an `imok`.

Netcat uses `select()`, `poll()`, `read()`, where `poll()` sometimes
throws an error because Zookeeper has closed the TCP connection.
Socat uses `select()`, `read()`, which works here.